### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/opml/views.py
+++ b/opml/views.py
@@ -85,4 +85,4 @@ class OPMLImportView(APIView):
             return Response({"error": "Invalid OPML file"}, status=status.HTTP_400_BAD_REQUEST)
         except Exception as e:
             logger.error(f"OPML import failed: {str(e)}")
-            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"error": "An internal error has occurred."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Potential fix for [https://github.com/tummyslyunopened/kneecap-backend/security/code-scanning/2](https://github.com/tummyslyunopened/kneecap-backend/security/code-scanning/2)

To fix the issue, we will replace the exposed exception message (`str(e)`) in the HTTP response with a generic error message, such as "An internal error has occurred." The detailed exception message will be logged on the server using the existing `logger.error` mechanism. This ensures that developers can still debug issues while preventing sensitive information from being exposed to end users.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
