### PR TITLE
fix: implement Timeline UI (#14)

### DIFF
--- a/dashboard/templates/feed.html
+++ b/dashboard/templates/feed.html
@@ -9,6 +9,7 @@
           <button class="menu-btn" onclick="toggleMenu()">☰</button>
           <div class="menu-content" id="menu-content">
             <a href="/subscriptions" class="menu-item">Subscriptions</a>
+            <a href="/timeline/" class="menu-item">Timeline</a>
           </div>
         </div>
         <form method="POST" class="subscription-form-row">

--- a/kneecap/urls.py
+++ b/kneecap/urls.py
@@ -3,6 +3,7 @@ from django.urls import path, include
 # from rss import urls as rss_urls
 # from api import urls as api_urls
 from opml import urls as opml_urls
+from timeline import urls as timeline_urls
 from django.conf import settings
 from django.conf.urls.static import static
 from dashboard.views import (
@@ -62,6 +63,7 @@ urlpatterns = [
         name="set_episode_playback_time",
     ),
     path("api/opml/", include(opml_urls)),
+    path("timeline/", include(timeline_urls)),
 ]
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/static/styles/base.css
+++ b/static/styles/base.css
@@ -350,3 +350,69 @@
 .queue-summary-mobile {
   padding-top: 50px;
 }
+
+.timeline {
+  padding-bottom: 60px;
+}
+
+.timeline-day-header {
+  background-color: #1b1340;
+  color: #fff;
+  margin: 0;
+  padding: 8px 12px;
+  font-size: 1rem;
+  position: sticky;
+  top: 44px;
+  z-index: 100;
+}
+
+.timeline-minute {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  border-bottom: 1px solid #ccc;
+  background-color: #e5e0f8;
+  transition: background-color 0.3s ease;
+  padding: 8px 12px;
+  gap: 12px;
+}
+
+.timeline-minute:hover {
+  background-color: #d1c9f0;
+}
+
+.timeline-minute-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.timeline-minute-time {
+  font-family: monospace;
+  font-weight: bold;
+  color: #1b1340;
+  font-size: 0.95rem;
+}
+
+.timeline-minute-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.timeline-minute-episode {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #333;
+}
+
+.timeline-minute-meta {
+  font-size: 0.8rem;
+  color: #555;
+}
+
+.timeline-empty {
+  background-color: #e5e0f8;
+}

--- a/timeline/templates/timeline.html
+++ b/timeline/templates/timeline.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% block title %}Timeline{% endblock %}
+{% block content %}
+<div class="main-content">
+  <div style="display: flex; flex-direction: row;">
+    <div class="feed-col">
+      <div class="sticky-header">
+        <a href="/" class="btn btn-secondary" target="_self">Feed</a>
+        <span style="color: #fff; padding: 0 12px;">Timeline</span>
+        <span style="color: #fff; padding: 0 12px;">{{ total_minutes }} minutes</span>
+      </div>
+
+      <div id="timeline" class="timeline">
+        {% if days %}
+          {% for day in days %}
+          <div class="timeline-day">
+            <h3 class="timeline-day-header">{{ day.day|date:"l, F j, Y" }}</h3>
+            {% for minute in day.minutes %}
+            <div class="timeline-minute" id="minute-{{ minute.pk }}">
+              <div class="image-container">
+                {% if minute.image_url %}
+                <img src="{{ minute.image_url }}" alt="Episode Image" width="60" />
+                {% endif %}
+              </div>
+              <div class="timeline-minute-body">
+                <div class="timeline-minute-time">{{ minute.time }}</div>
+                <div class="timeline-minute-title">
+                  <strong>{{ minute.episode.subscription.title }}</strong>
+                </div>
+                <div class="timeline-minute-episode">{{ minute.episode.title }}</div>
+                <div class="timeline-minute-meta">at {{ minute.playback_time_str }}</div>
+              </div>
+            </div>
+            {% endfor %}
+          </div>
+          {% endfor %}
+        {% else %}
+          <div class="timeline-empty">
+            <p style="padding: 2rem; text-align: center;">
+              No minutes recorded yet. Start playing an episode and the timeline will fill in.
+            </p>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/timeline/tests/test_timeline_view.py
+++ b/timeline/tests/test_timeline_view.py
@@ -1,0 +1,40 @@
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+
+from player.models import Player
+from subscriptions.models import Episode, Subscription
+from timeline.models import Minute
+
+
+class TestTimelineView(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.subscription = Subscription.objects.create(
+            link="http://test.com/rss",
+            title="Test Show",
+            image_url="http://test.com/img.jpg",
+        )
+        self.episode = Episode.objects.create(
+            subscription=self.subscription,
+            title="Test Episode",
+            pub_date=timezone.now(),
+            playback_time=125,
+        )
+        player = Player.get_solo()
+        player.episode = self.episode
+        player.save()
+
+    def test_timeline_renders_empty(self):
+        response = self.client.get(reverse("timeline"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Timeline")
+        self.assertContains(response, "No minutes recorded yet")
+
+    def test_timeline_renders_recorded_minute(self):
+        Minute.record()
+        response = self.client.get(reverse("timeline"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Test Show")
+        self.assertContains(response, "Test Episode")
+        self.assertContains(response, "00:02:05")

--- a/timeline/urls.py
+++ b/timeline/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from timeline.views import timeline
+
+urlpatterns = [
+    path("", timeline, name="timeline"),
+]

--- a/timeline/views.py
+++ b/timeline/views.py
@@ -1,0 +1,37 @@
+from collections import OrderedDict
+
+from django.shortcuts import render
+
+from timeline.models import Minute
+
+
+def _format_playback_time(seconds):
+    seconds = int(seconds or 0)
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+    secs = seconds % 60
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
+def timeline(request):
+    minutes = (
+        Minute.objects.select_related("episode", "episode__subscription")
+        .order_by("-created_at")[:1440]
+    )
+
+    days = OrderedDict()
+    for minute in minutes:
+        day_key = minute.created_at.date()
+        days.setdefault(day_key, []).append(
+            {
+                "pk": minute.pk,
+                "time": minute.created_at.strftime("%H:%M"),
+                "episode": minute.episode,
+                "image_url": minute.image,
+                "playback_time_str": _format_playback_time(minute.playback_time),
+            }
+        )
+
+    grouped = [{"day": day, "minutes": items} for day, items in days.items()]
+    context = {"days": grouped, "total_minutes": len(minutes)}
+    return render(request, "timeline.html", context=context)


### PR DESCRIPTION
## Summary
- Adds a `/timeline/` page that lists recorded `Minute` rows grouped by day, showing time, subscription, episode, image, and the playback position captured at that minute.
- Wires the new view into `kneecap/urls.py` and adds a Timeline link to the feed page hamburger menu.
- Adds basic timeline styles to `static/styles/base.css` and a view-level test.

Closes #14

## Test plan
- [x] `manage.py test timeline` — 7/7 pass
- [ ] Manual: load `/timeline/` with no minutes recorded — empty-state message renders
- [ ] Manual: play an episode, run `record_minutes`, reload `/timeline/` — entries appear under today's date with correct image, episode, and playback time

🤖 Generated with [Claude Code](https://claude.com/claude-code)