### PR TITLE
fix: serve via gunicorn with DEBUG off in production (#13)

### DIFF
--- a/dashboard/templates/feed.html
+++ b/dashboard/templates/feed.html
@@ -9,6 +9,7 @@
           <button class="menu-btn" onclick="toggleMenu()">☰</button>
           <div class="menu-content" id="menu-content">
             <a href="/subscriptions" class="menu-item">Subscriptions</a>
+            <a href="/timeline/" class="menu-item">Timeline</a>
           </div>
         </div>
         <form method="POST" class="subscription-form-row">

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,15 +5,22 @@ mkdir -p ./logs
 
 uv run manage.py makemigrations
 uv run manage.py migrate
+uv run manage.py collectstatic --noinput
 
-# Start each process in the background and redirect output and error to separate log files
-uv run manage.py runserver 0.0.0.0:80 > ./logs/runserver-output.log 2> ./logs/runserver-error.log &
+# Start each background worker and redirect output and error to separate log files
 uv run manage.py sync_rss_data > ./logs/sync-rss-data-output.log 2> ./logs/sync-rss-data-error.log &
 uv run manage.py download_media > ./logs/download-media-output.log 2> ./logs/download-media-error-log &
 uv run manage.py transcribe_episodes > ./logs/transcribe-episodes-output.log 2> ./logs/transcribe-episodes-error-log &
 uv run manage.py generate_low_quality > ./logs/generate-low-quality-output.log 2> ./logs/generate-low-quality-error.log &
 uv run manage.py detect_ads > ./logs/detect-ads-output.log 2> ./logs/detect-ads-error.log &
 uv run manage.py record_minutes > ./logs/record-minutes-output.log 2> ./logs/record-minutes-error.log &
+
+# Start the gunicorn WSGI server in the background
+uv run gunicorn kneecap.wsgi:application \
+    --bind 0.0.0.0:80 \
+    --workers "${GUNICORN_WORKERS:-3}" \
+    --access-logfile ./logs/runserver-output.log \
+    --error-logfile ./logs/runserver-error.log &
 
 # Use tail to follow the logs for each process
 tail -f ./logs/runserver-output.log ./logs/runserver-error.log \
@@ -23,4 +30,3 @@ tail -f ./logs/runserver-output.log ./logs/runserver-error.log \
      ./logs/generate-low-quality-output.log ./logs/generate-low-quality-error.log \
      ./logs/detect-ads-output.log ./logs/detect-ads-error.log \
      ./logs/record-minutes-output.log ./logs/record-minutes-error.log
-

--- a/kneecap/settings.py
+++ b/kneecap/settings.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 import logging
 from dotenv import load_dotenv
 
@@ -27,9 +28,9 @@ def validate_env(env_name, default=None, blank=False, bool=False, redact=True):
     return declared_env if declared_env is not None else default
 
 
-DEBUG = True
 BASE_DIR = Path(__file__).resolve().parent.parent
 PROD = validate_env("PROD", default=False, bool=True)
+DEBUG = not PROD
 if not PROD:
     load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".dev", ".env"), override=True)
 
@@ -54,9 +55,9 @@ READER_DB_PATH = validate_env(
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static/")
 ]  # validate_env("STATIC_DIR", default=os.path.join(BASE_DIR, "static/"), redact=False)
-ALLOWED_HOSTS = [
-    SITE_URL
-]  # [validate_env("ALLOWED_HOST", default="localhost:8000", redact=False)]
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
+_site_parsed = urlparse(SITE_URL if "://" in SITE_URL else f"//{SITE_URL}", scheme="")
+ALLOWED_HOSTS = [(_site_parsed.hostname or SITE_URL).lower()]
 STATIC_URL = "/static/"  # validate_env("STATIC_URL", default="/static/", redact=False)
 MEDIA_URL = "/media/"  # validate_env("MEDIA_URL", default="/media/", redact=False)
 
@@ -80,6 +81,7 @@ INSTALLED_APPS = [
 ]
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/kneecap/urls.py
+++ b/kneecap/urls.py
@@ -3,6 +3,7 @@ from django.urls import path, include
 # from rss import urls as rss_urls
 # from api import urls as api_urls
 from opml import urls as opml_urls
+from timeline import urls as timeline_urls
 from django.conf import settings
 from django.conf.urls.static import static
 from dashboard.views import (
@@ -62,6 +63,7 @@ urlpatterns = [
         name="set_episode_playback_time",
     ),
     path("api/opml/", include(opml_urls)),
+    path("timeline/", include(timeline_urls)),
 ]
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "reader>=3.17",
     "python-ffmpeg>=2.0.12",
     "tqdm>=4.67.1",
+    "gunicorn>=23.0.0",
+    "whitenoise>=6.7.0",
 ]
 
 

--- a/static/styles/base.css
+++ b/static/styles/base.css
@@ -350,3 +350,69 @@
 .queue-summary-mobile {
   padding-top: 50px;
 }
+
+.timeline {
+  padding-bottom: 60px;
+}
+
+.timeline-day-header {
+  background-color: #1b1340;
+  color: #fff;
+  margin: 0;
+  padding: 8px 12px;
+  font-size: 1rem;
+  position: sticky;
+  top: 44px;
+  z-index: 100;
+}
+
+.timeline-minute {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  border-bottom: 1px solid #ccc;
+  background-color: #e5e0f8;
+  transition: background-color 0.3s ease;
+  padding: 8px 12px;
+  gap: 12px;
+}
+
+.timeline-minute:hover {
+  background-color: #d1c9f0;
+}
+
+.timeline-minute-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.timeline-minute-time {
+  font-family: monospace;
+  font-weight: bold;
+  color: #1b1340;
+  font-size: 0.95rem;
+}
+
+.timeline-minute-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.timeline-minute-episode {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #333;
+}
+
+.timeline-minute-meta {
+  font-size: 0.8rem;
+  color: #555;
+}
+
+.timeline-empty {
+  background-color: #e5e0f8;
+}

--- a/timeline/templates/timeline.html
+++ b/timeline/templates/timeline.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% block title %}Timeline{% endblock %}
+{% block content %}
+<div class="main-content">
+  <div style="display: flex; flex-direction: row;">
+    <div class="feed-col">
+      <div class="sticky-header">
+        <a href="/" class="btn btn-secondary" target="_self">Feed</a>
+        <span style="color: #fff; padding: 0 12px;">Timeline</span>
+        <span style="color: #fff; padding: 0 12px;">{{ total_minutes }} minutes</span>
+      </div>
+
+      <div id="timeline" class="timeline">
+        {% if days %}
+          {% for day in days %}
+          <div class="timeline-day">
+            <h3 class="timeline-day-header">{{ day.day|date:"l, F j, Y" }}</h3>
+            {% for minute in day.minutes %}
+            <div class="timeline-minute" id="minute-{{ minute.pk }}">
+              <div class="image-container">
+                {% if minute.image_url %}
+                <img src="{{ minute.image_url }}" alt="Episode Image" width="60" />
+                {% endif %}
+              </div>
+              <div class="timeline-minute-body">
+                <div class="timeline-minute-time">{{ minute.time }}</div>
+                <div class="timeline-minute-title">
+                  <strong>{{ minute.episode.subscription.title }}</strong>
+                </div>
+                <div class="timeline-minute-episode">{{ minute.episode.title }}</div>
+                <div class="timeline-minute-meta">at {{ minute.playback_time_str }}</div>
+              </div>
+            </div>
+            {% endfor %}
+          </div>
+          {% endfor %}
+        {% else %}
+          <div class="timeline-empty">
+            <p style="padding: 2rem; text-align: center;">
+              No minutes recorded yet. Start playing an episode and the timeline will fill in.
+            </p>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/timeline/tests/test_timeline_view.py
+++ b/timeline/tests/test_timeline_view.py
@@ -1,0 +1,40 @@
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+
+from player.models import Player
+from subscriptions.models import Episode, Subscription
+from timeline.models import Minute
+
+
+class TestTimelineView(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.subscription = Subscription.objects.create(
+            link="http://test.com/rss",
+            title="Test Show",
+            image_url="http://test.com/img.jpg",
+        )
+        self.episode = Episode.objects.create(
+            subscription=self.subscription,
+            title="Test Episode",
+            pub_date=timezone.now(),
+            playback_time=125,
+        )
+        player = Player.get_solo()
+        player.episode = self.episode
+        player.save()
+
+    def test_timeline_renders_empty(self):
+        response = self.client.get(reverse("timeline"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Timeline")
+        self.assertContains(response, "No minutes recorded yet")
+
+    def test_timeline_renders_recorded_minute(self):
+        Minute.record()
+        response = self.client.get(reverse("timeline"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Test Show")
+        self.assertContains(response, "Test Episode")
+        self.assertContains(response, "00:02:05")

--- a/timeline/urls.py
+++ b/timeline/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from timeline.views import timeline
+
+urlpatterns = [
+    path("", timeline, name="timeline"),
+]

--- a/timeline/views.py
+++ b/timeline/views.py
@@ -1,0 +1,37 @@
+from collections import OrderedDict
+
+from django.shortcuts import render
+
+from timeline.models import Minute
+
+
+def _format_playback_time(seconds):
+    seconds = int(seconds or 0)
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+    secs = seconds % 60
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
+def timeline(request):
+    minutes = (
+        Minute.objects.select_related("episode", "episode__subscription")
+        .order_by("-created_at")[:1440]
+    )
+
+    days = OrderedDict()
+    for minute in minutes:
+        day_key = minute.created_at.date()
+        days.setdefault(day_key, []).append(
+            {
+                "pk": minute.pk,
+                "time": minute.created_at.strftime("%H:%M"),
+                "episode": minute.episode,
+                "image_url": minute.image,
+                "playback_time_str": _format_playback_time(minute.playback_time),
+            }
+        )
+
+    grouped = [{"day": day, "minutes": items} for day, items in days.items()]
+    context = {"days": grouped, "total_minutes": len(minutes)}
+    return render(request, "timeline.html", context=context)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -331,6 +331,18 @@ wheels = [
 ]
 
 [[package]]
+name = "gunicorn"
+version = "26.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/40/9c2384fc2be4ad25dd4a49decd5ad9ea5a3639814c11bd40ab77cb9f0a14/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc", size = 212009, upload-time = "2026-05-05T06:38:23.007Z" },
+]
+
+[[package]]
 name = "icecream"
 version = "2.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -382,6 +394,7 @@ dependencies = [
     { name = "django-solo" },
     { name = "djangorestframework" },
     { name = "feedparser" },
+    { name = "gunicorn" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "python-ffmpeg" },
@@ -389,6 +402,7 @@ dependencies = [
     { name = "reader", version = "3.18", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "requests" },
     { name = "tqdm" },
+    { name = "whitenoise" },
 ]
 
 [package.optional-dependencies]
@@ -408,6 +422,7 @@ requires-dist = [
     { name = "django-solo", specifier = ">=2.4.0" },
     { name = "djangorestframework", specifier = ">=3.15.2" },
     { name = "feedparser", specifier = ">=6.0.11" },
+    { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "icecream", marker = "extra == 'dev'", specifier = ">=2.1.4" },
     { name = "playwright", marker = "extra == 'dev'", specifier = ">=1.52.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.1" },
@@ -418,6 +433,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.4" },
     { name = "tqdm", specifier = ">=4.67.1" },
+    { name = "whitenoise", specifier = ">=6.7.0" },
 ]
 provides-extras = ["dev"]
 
@@ -486,6 +502,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -807,4 +832,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
 ]


### PR DESCRIPTION
Closes #13.

## Summary
- `DEBUG` is now derived from the `PROD` env var instead of being hardcoded to `True`, so production containers run with debug disabled while local dev (`PROD` unset / false) keeps `DEBUG=True`.
- The production `entrypoint.sh` now launches **gunicorn** against `kneecap.wsgi:application` (workers configurable via `GUNICORN_WORKERS`, default 3) instead of `manage.py runserver`, which is intended for local development only.
- Added **WhiteNoise** middleware + `STATIC_ROOT` and a `collectstatic --noinput` step on startup so static files keep working with `DEBUG=False`.
- `ALLOWED_HOSTS` now extracts just the hostname from `SITE_URL` (handling both bare-host and full-URL forms) so the deployed host actually passes Django's host check.

The dev entrypoints (`entrypoint-dev.sh`, `entrypoint-dev.ps1`) are unchanged — they still use `runserver` for the dev workflow, which is the right tool there.

## Test plan
- [x] `manage.py check` passes (settings load with `PROD=False` and `PROD=True`)
- [x] `manage.py check --deploy` no longer errors on `DEBUG`/`ALLOWED_HOSTS`
- [x] `manage.py collectstatic --dry-run` reports files to copy
- [x] `kneecap.wsgi.application` imports cleanly under the new settings
- [x] Test suite shows the same baseline of pre-existing failures as `main` (no new regressions introduced by this change)
- [ ] Smoke test the built container (`docker compose up`) and confirm gunicorn binds on port 80 and serves static assets