### PR TITLE
fix: finish playback speed UI button handlers (#5)

### DIFF
--- a/static/js/audioPlayer.js
+++ b/static/js/audioPlayer.js
@@ -1,6 +1,5 @@
 import { CONSTANTS, state } from './base.js';
 import ApiService from './apiService.js';
-import { safeGetElement } from './utils.js';
 
 /**
  * AudioPlayer class handles all audio playback functionality
@@ -64,21 +63,8 @@ class AudioPlayer {
     this.progressHandle?.addEventListener('mousedown', this.startDrag.bind(this));
     
     // Playback rate controls
-    const handleRateIncrease = () => {
-      this.adjustPlaybackRate(0.25);
-    };
-    
-    const handleRateDecrease = () => {
-      this.adjustPlaybackRate(-0.25);
-    };
-    
-    if (this.increasePlaybackRateButton) {
-      this.increasePlaybackRateButton.addEventListener('click', handleRateIncrease);
-    }
-    
-    if (this.decreasePlaybackRateButton) {
-      this.decreasePlaybackRateButton.addEventListener('click', handleRateDecrease);
-    }
+    this.increasePlaybackRateButton?.addEventListener('click', () => this.adjustPlaybackRate(0.25));
+    this.decreasePlaybackRateButton?.addEventListener('click', () => this.adjustPlaybackRate(-0.25));
     
     // Audio element events
     const events = [
@@ -251,27 +237,23 @@ class AudioPlayer {
    * @param {number} increment - The amount to adjust the playback rate by (can be positive or negative)
    */
   adjustPlaybackRate(increment) {
-    if (!this.audio) {
-      return;
-    }
-    
-    // Define the range of allowed playback rates
+    if (!this.audio) return;
+
     const minRate = 0.5;
     const maxRate = 3.0;
     const step = 0.25;
-    
-    // Calculate new rate and round to nearest step to avoid floating point precision issues
+
     let newRate = Math.round((this.audio.playbackRate + increment) / step) * step;
-    
-    // Clamp the value within allowed range
     newRate = Math.min(maxRate, Math.max(minRate, newRate));
-    
-    // Only update if rate has changed
-    if (newRate !== this.audio.playbackRate) {
-      this.audio.playbackRate = newRate;
-      this.updatePlaybackRateDisplay();
-    } else {
-      console.log('Playback rate unchanged');
+
+    if (newRate === this.audio.playbackRate) return;
+
+    this.audio.playbackRate = newRate;
+    state.playbackRate = newRate;
+    this.updatePlaybackRateDisplay();
+
+    if (typeof window.updateQueueDuration === 'function') {
+      window.updateQueueDuration();
     }
   }
 
@@ -279,23 +261,10 @@ class AudioPlayer {
    * Updates the UI to reflect the current playback rate
    */
   updatePlaybackRateDisplay() {
-    console.log('Updating playback rate display');
-    
-    if (!this.audio) {
-      console.error('No audio element for rate display');
-      return;
-    }
-    
-    // Update any UI elements that show playback rate
+    if (!this.audio) return;
     const rateDisplay = document.querySelector('.playback-rate-display');
-    console.log('Rate display element:', rateDisplay);
-    
     if (rateDisplay) {
-      const rateText = `${this.audio.playbackRate.toFixed(2)}x`;
-      console.log('Setting rate display text to:', rateText);
-      rateDisplay.textContent = rateText;
-    } else {
-      console.warn('No element with class "playback-rate-display" found');
+      rateDisplay.textContent = `${this.audio.playbackRate.toFixed(2)}x`;
     }
   }
 
@@ -323,9 +292,11 @@ class AudioPlayer {
       return;
     }
     
-    // Update playback rate in state
-    state.playbackRate = this.audio.playbackRate;
-    safeGetElement('playback-rate-label').textContent = `${state.playbackRate}x`;
+    // Keep state in sync with the audio element in case the rate was changed elsewhere
+    if (state.playbackRate !== this.audio.playbackRate) {
+      state.playbackRate = this.audio.playbackRate;
+      this.updatePlaybackRateDisplay();
+    }
     state.lastRecordedPlaybackTime = currentTime;
 
     


### PR DESCRIPTION
Closes #5

## Summary
The increase/decrease playback-rate buttons were already wired up in `audioPlayer.js`, but the implementation had a few gaps that prevented the UI from behaving as a finished feature:

- `state.playbackRate` was only updated inside `logPlaybackTime`, which fires while audio is *playing*. Clicking a rate button while paused changed `audio.playbackRate` but left `state.playbackRate` stale — so the queue-duration calculation (which divides by `state.playbackRate`) lagged behind the audio element until playback resumed.
- `logPlaybackTime` overwrote the rate label with `` `${state.playbackRate}x` `` (e.g. `"1x"`), conflicting with `updatePlaybackRateDisplay`'s formatted `"1.00x"`. The label would flicker between the two formats once audio started.
- `adjustPlaybackRate` and `updatePlaybackRateDisplay` were full of `console.log`/`console.warn` debug noise.
- The queue duration only refreshed on its 1s interval, so a rate change took up to a second to visibly affect the queue summary.

## Changes
- `adjustPlaybackRate` now updates `state.playbackRate` and calls `window.updateQueueDuration()` so the queue summary reflects the new rate immediately, regardless of play state.
- `updatePlaybackRateDisplay` is now the single source of truth for the rate label; the conflicting overwrite in `logPlaybackTime` is replaced with a guarded sync that only acts when the audio element's rate diverges from state.
- Removed verbose debug logging from the rate path.
- Simplified rate button event wiring with optional chaining.
- Dropped the now-unused `safeGetElement` import.

## Test plan
- [ ] Load a feed with an episode in the player; rate label reads `1.00x`.
- [ ] Click `+` while paused → label updates to `1.25x` and the queue duration summary recalculates immediately.
- [ ] Click `-` repeatedly → rate clamps at `0.50x` and the label/queue stay in sync.
- [ ] Click `+` repeatedly → rate clamps at `3.00x`.
- [ ] Start playback at a non-1x rate → label stays in the `N.NNx` format and doesn't flicker.